### PR TITLE
feat: Allow extra paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This GitHub Action automates the process of building, testing, and deploying a v
 - **Automatic Deployment**: Automatically deploys your mdBook documentation to the `gh-pages` branch.
 - **Version Control**: Deploys different versions of your documentation based on the branch or custom input.
 - **Testing Support**: Optionally runs `mdbook test` before deploying to ensure the book is functional.
+- **Extra Published Assets**: Can copy a few additional generated paths, such as rustdoc output, into the same publish branch.
 - **Customizable**: Supports custom mdBook versions, output directories, and more.
 
 ## Example Workflow
@@ -46,6 +47,8 @@ jobs:
           version: ${{ inputs.version || github.ref_name }}
           docs-dir: ${{ inputs.docs-dir || 'docs' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          additional-paths: |
+            target/doc=api
 ```
 
 
@@ -103,6 +106,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-tests: true
           mdbook-version: "v0.4.40"
+          additional-paths: |
+            target/doc=api
 ```
 
 ## Inputs
@@ -117,6 +122,8 @@ jobs:
 | `project`          | `string`  | ❌        | ``            | Name of the project to build the book for for multi-project repositories only. |
 | `publish-branch`   | `string`  | ❌        | `gh-pages`    | The branch to publish documenation to.                                         |
 | `deploy`           | `boolean` | ❌        | `true`        | Enable or disable deployment. Can be used in testing purposes.                 |
+| `create-latest-symlink` | `boolean` | ❌   | `false`       | Create a `latest` symlink that points to the deployed version.                 |
+| `additional-paths` | `string`  | ❌        | ``            | Newline-separated `source=destination` mappings copied into the publish branch. |
 
 ## Outputs
 
@@ -127,6 +134,8 @@ jobs:
 - Action is supported on Linux only.
 - If the `gh-pages` branch does not exist, it will be created automatically.
 - Make sure that GitHub Pages is set to deploy from the `gh-pages` branch in your repository settings.
+- `additional-paths` destinations are relative to the publish branch root and must stay inside it.
+- When a source mapping points to a directory, the action replaces the destination directory before copying the new contents.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,11 @@ inputs:
     description: "Create a symlink to the latest version"
     required: false
     default: false
+  additional-paths:
+    type: string
+    description: "Additional source=destination mappings to copy into the publish branch"
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -177,6 +182,7 @@ runs:
       shell: 'bash -ex {0}'
       env:
         VERSION: ${{ steps.build-book.outputs.version }}
+        ADDITIONAL_PATHS: ${{ inputs.additional-paths }}
       run: |
         echo "::group::Deploying the book"
         BOOK_DIR=$(readlink -f "${{ inputs.docs-dir }}/${VERSION}")
@@ -185,12 +191,57 @@ runs:
         rm -rf ${VERSION}
         # Move the new version of the book
         mv "${BOOK_DIR}" "${VERSION}"
-        # Add the new version of the book
-        git add "${VERSION}" versions.json
+        # Stage the new version of the book and the updated version selector.
+        git add -A -- "${VERSION}" versions.json
         if [ ${{ inputs.create-latest-symlink }} == 'true' ]; then
           rm -f latest
           ln -sfn "${VERSION}" latest
-          git add latest
+          git add -A -- latest
+        fi
+
+        # Some projects publish generated assets alongside the book, such as
+        # rustdoc output. These mappings let the action keep owning the pages
+        # branch while still updating a few extra directories in the same deploy.
+        if [ ! -z "${ADDITIONAL_PATHS}" ]; then
+          while IFS= read -r mapping; do
+            [ -z "${mapping}" ] && continue
+
+            if [[ "${mapping}" != *=* ]]; then
+              echo "::error title=⛔ invalid additional-paths entry::Expected source=destination, got '${mapping}'."
+              exit 1
+            fi
+
+            SOURCE_PATH="${mapping%%=*}"
+            DESTINATION_PATH="${mapping#*=}"
+
+            if [ -z "${SOURCE_PATH}" ] || [ -z "${DESTINATION_PATH}" ]; then
+              echo "::error title=⛔ invalid additional-paths entry::Both source and destination must be non-empty in '${mapping}'."
+              exit 1
+            fi
+
+            if [[ "${DESTINATION_PATH}" == /* ]] || [[ "${DESTINATION_PATH}" == ../* ]] || [[ "${DESTINATION_PATH}" == *"/../"* ]] || [[ "${DESTINATION_PATH}" == *"/.." ]]; then
+              echo "::error title=⛔ invalid additional-paths destination::Destination '${DESTINATION_PATH}' must stay inside the publish branch."
+              exit 1
+            fi
+
+            SOURCE_ABS_PATH=$(readlink -f "${SOURCE_PATH}")
+            if [ ! -e "${SOURCE_ABS_PATH}" ]; then
+              echo "::error title=⛔ missing additional-paths source::Source '${SOURCE_PATH}' does not exist."
+              exit 1
+            fi
+
+            rm -rf "${DESTINATION_PATH}"
+            mkdir -p "$(dirname "${DESTINATION_PATH}")"
+
+            if [ -d "${SOURCE_ABS_PATH}" ]; then
+              mkdir -p "${DESTINATION_PATH}"
+              cp -a "${SOURCE_ABS_PATH}/." "${DESTINATION_PATH}/"
+            else
+              cp -a "${SOURCE_ABS_PATH}" "${DESTINATION_PATH}"
+            fi
+
+            git add -A -- "${DESTINATION_PATH}"
+          done <<< "${ADDITIONAL_PATHS}"
         fi
         git commit --amend -m "Deploy ${GITHUB_SHA::7}"
         git push --force --set-upstream origin ${{ inputs.publish-branch }}


### PR DESCRIPTION
I have a project where I want to deploy cargo doc output alongside the docs, so this change would let me do it without dirty hacks while reusing the same workflow. 